### PR TITLE
Add remove focus tooltip and clear query on return

### DIFF
--- a/src/components/droppable/focus/focus-dropdown.tsx
+++ b/src/components/droppable/focus/focus-dropdown.tsx
@@ -43,7 +43,6 @@ export default function FocusDropdown() {
                 <DropdownMenu className='w-[250px] rounded-none p-0'>
                     <DropdownSection className='rounded-none'>
                         <DropdownItem isReadOnly className='p-0 rounded-none mt-2'>
-                            <FocusBox focus={Focus.Self} display='Self' />
                             <FocusBox focus={Focus.Descendants} display='Descendants' />
                             <FocusBox focus={Focus.DescendantsOrSelf} display='Descendants or Self' />
                             <FocusBox focus={Focus.ChildrenOrSelf} display='Child or Self' />

--- a/src/components/query-builder/drop-area/query-drop-area.tsx
+++ b/src/components/query-builder/drop-area/query-drop-area.tsx
@@ -47,9 +47,9 @@ export const QueryDropArea: FC<QueryDropAreaProps> = memo(function QueryBox({
 
     const handleDrop = (index: number, item: any, depth: number | undefined, groupIndex: number[] | undefined) => {
         if (item.focus) {
-            if (groupIndex?.length == 0 && typeof depth === 'number') {
+            if (groupIndex?.length === 1 && typeof depth === 'number') {
                 addFocusToQueryGrouping(index, item.focus, depth);
-            } else if (groupIndex?.length === 1 && typeof depth === 'number') {
+            } else if (groupIndex?.length === 2 && typeof depth === 'number') {
                 addFocusToQuerySubGrouping(index, item.focus, groupIndex[0], depth);
             } else {
                 addFocusToQuery(index, item.focus);

--- a/src/components/query-builder/query-builder.tsx
+++ b/src/components/query-builder/query-builder.tsx
@@ -55,6 +55,16 @@ export default function QueryBuilder() {
     }
   }, [queries]);
 
+  const runQuery = async () => {
+    if (query?.id) {
+      runUpdateQuery();
+    } else {
+      runSaveQuery();
+    }
+
+    router.push('/results');
+  };
+
   const runSaveQuery = async () => {
     setIsLoading(true);
     const newQuery: SavedQuery = { ...query };
@@ -62,8 +72,6 @@ export default function QueryBuilder() {
 
     saveQuery(newQuery, {
       onSuccess: (response) => {
-        successToast("Query saved");
-
         updateQueryStore(response.data);
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.LIST_QUERIES });
         setIsLoading(false);
@@ -82,8 +90,6 @@ export default function QueryBuilder() {
 
     updateQuery(updatedQuery, {
       onSuccess: (response) => {
-        successToast("Query saved");
-
         updateQueryStore(response.data);
         queryClient.invalidateQueries({ queryKey: QUERY_KEYS.LIST_QUERIES });
         setIsLoading(false);
@@ -172,13 +178,7 @@ export default function QueryBuilder() {
                   <Input label='Add Query Name' value={query.name} onValueChange={setQueryName} variant="bordered" className='max-w-xs p-3' isRequired />
                   <div className='flex my-auto'>
                     <Button className='m-2' color='primary' startContent={<PreviewIcon />} onClick={getPreview} onPress={onOpen}>Preview Sample Query</Button>
-                    {!query?.id &&
-                      <Button className='m-2' endContent={<SaveIcon />} onClick={runSaveQuery} isDisabled={isDisabled()}>Save Query</Button>
-                    }
-                    {query?.id &&
-                      <Button className='m-2' endContent={<SaveIcon />} onClick={runUpdateQuery}>Update Query</Button>
-                    }
-                    <Button className='m-2' color='primary' endContent={<ArrowForwardIcon />} onPress={() => router.push('/results')} isDisabled={isDisabled()}>Run Query</Button>
+                    <Button className='m-2' color='primary' endContent={<ArrowForwardIcon />} onPress={() => runQuery()} isDisabled={isDisabled()}>Run Query</Button>
                   </div>
                 </div>
               </div>

--- a/src/components/query-builder/results-table.tsx
+++ b/src/components/query-builder/results-table.tsx
@@ -21,7 +21,7 @@ export const ResultsTable: FC<ResultsTableProps> = ({ }) => {
     const { readString } = usePapaParse();
 
     const { mutate: postQuery, data: queryResults } = usePostQuery();
-    const { query, updateIsReturn } = useQueryStore();
+    const { query, updateIsReturn, clearQuery } = useQueryStore();
 
     const fetchData = useMemo(() => {
         if (query.query) {
@@ -149,6 +149,7 @@ export const ResultsTable: FC<ResultsTableProps> = ({ }) => {
 
     const returnToBuilder = () => {
         updateIsReturn(true);
+        clearQuery();
         router.push('/query-builder');
     };
 

--- a/src/components/ui/focus-render.tsx
+++ b/src/components/ui/focus-render.tsx
@@ -8,27 +8,27 @@ export interface FocusRenderProps {
 export const FocusRender: FC<FocusRenderProps> = ({ focus }) => {
     switch (focus) {
         case Focus.Ancestors:
-            return <>Ancestors</>;
+            return <>Ancestors&nbsp;</>;
         case Focus.AncestorsOrSelf:
-            return <>Ancestors or Self</>;
+            return <>Ancestors or Self&nbsp;</>;
         case Focus.Children:
-            return <>Child</>;
+            return <>Child&nbsp;</>;
         case Focus.ChildrenOrSelf:
-            return <>Child or Self</>;
+            return <>Child or Self&nbsp;</>;
         case Focus.Date:
-            return <>Date</>;
+            return <>Date&nbsp;</>;
         case Focus.Descendants:
-            return <>Descendants</>;
+            return <>Descendants&nbsp;</>;
         case Focus.DescendantsOrSelf:
-            return <>Descendants or Self</>;
+            return <>Descendants or Self&nbsp;</>;
         case Focus.Member:
-            return <>Member</>;
+            return <>Member&nbsp;</>;
         case Focus.Parent:
-            return <>Parent</>;
+            return <>Parent&nbsp;</>;
         case Focus.ParentOrSelf:
-            return <>Parent or Self</>;
+            return <>Parent or Self&nbsp;</>;
         case Focus.Self:
-            return <>Self</>;
+            return <></>;
     }
 
     return <></>;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -7,6 +7,7 @@ interface QueryStore {
     query: SavedQuery;
     queryList: Array<SavedQuery>;
     isReturn: boolean;
+    clearQuery: () => void;
     updateIsReturn: (isReturn: boolean) => void;
     updateQueryStore: (query: SavedQuery) => void;
     updateQueryListStore: (queryList: Array<SavedQuery>) => void;
@@ -73,6 +74,12 @@ export const useQueryStore = create<QueryStore>()(
         query: { query: { queries: [], unitOutput: UnitOutput.Imperial } },
         queryList: [],
         isReturn: false,
+        clearQuery: () =>
+            set(
+                produce((draft) => {
+                    draft.query = { query: { queries: [], unitOutput: UnitOutput.Imperial } }
+                })
+            ),
         updateIsReturn: (isReturn) =>
             set(
                 produce((draft) => {


### PR DESCRIPTION
If Focus is `Self`, do not show it.
Run Query now saves the query, removes dedicated save/update button and returning from results clears builder